### PR TITLE
Fixing a large chunk of warnings caused by env spec mismatch with tests

### DIFF
--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -20,117 +20,125 @@ very uncommon and these features should be included whenever possible as all
 standard learning code requires these properties. Also not that if you do not
 have {name} it should also not be possible for you to expose the possible_agents
 list and observation_spaces, action_spaces dictionaries."""
+env_obs_dicts = [
+    "leduc_holdem_v4",
+    "texas_holdem_no_limit_v6",
+    "texas_holdem_v4",
+    "go_v5",
+    "hanabi_v4",
+    "chess_v5",
+    "connect_four_v3",
+    "tictactoe_v3",
+    "gin_rummy_v4",
+]
+env_graphical_obs = ["knights_archers_zombies_v10"]
+env_diff_obs_shapes = [
+    "simple_adversary_v2",
+    "simple_world_comm_v2",
+    "simple_tag_v2",
+    "knights_archers_zombies_v10",
+    "simple_push_v2",
+    "simple_speaker_listener_v3",
+    "simple_crypto_v2",
+]
+env_all_zeros_obs = ["knights_archers_zombies_v10"]
+env_obs_space = [
+    "leduc_holdem_v4",
+    "texas_holdem_no_limit_v6",
+    "texas_holdem_v4",
+    "go_v5",
+    "hanabi_v4",
+    "knights_archers_zombies_v10",
+    "chess_v5",
+    "connect_four_v3",
+    "tictactoe_v3",
+    "gin_rummy_v4",
+]
+env_diff_agent_obs_size = [
+    "simple_adversary_v2",
+    "simple_world_comm_v2",
+    "simple_tag_v2",
+    "simple_crypto_v2",
+    "simple_push_v2",
+    "simple_speaker_listener_v3",
+]
+env_pos_inf_obs = [
+    "simple_adversary_v2",
+    "simple_reference_v2",
+    "simple_spread_v2",
+    "simple_tag_v2",
+    "simple_world_comm_v2",
+    "multiwalker_v9",
+    "simple_crypto_v2",
+    "simple_push_v2",
+    "simple_speaker_listener_v3",
+    "simple_v2",
+]
+env_neg_inf_obs = [
+    "simple_adversary_v2",
+    "simple_reference_v2",
+    "simple_spread_v2",
+    "simple_tag_v2",
+    "simple_world_comm_v2",
+    "multiwalker_v9",
+    "simple_crypto_v2",
+    "simple_push_v2",
+    "simple_speaker_listener_v3",
+    "simple_v2",
+]
 
 
 def test_observation(observation, observation_0, env_name=None):
-    env_dicts = [
-        "leduc_holdem_v4",
-        "texas_holdem_no_limit_v6",
-        "texas_holdem_v4",
-        "go_v5",
-        "hanabi_v4",
-        "chess_v5",
-        "connect_four_v3",
-        "tictactoe_v3",
-        "gin_rummy_v4",
-    ]
-    env_graphical_obs = ["knights_archers_zombies_v10"]
-    env_diff_obs_shapes = [
-        "simple_adversary_v2",
-        "simple_world_comm_v2",
-        "simple_tag_v2",
-        "knights_archers_zombies_v10",
-        "simple_push_v2",
-        "simple_speaker_listener_v3",
-        "simple_crypto_v2",
-    ]
-    env_all_zeros_obs = ["knights_archers_zombies_v10"]
-    if isinstance(observation, np.ndarray):
-        if np.isinf(observation).any():
-            warnings.warn(
-                "Observation contains infinity (np.inf) or negative infinity (-np.inf)"
-            )
-        if np.isnan(observation).any():
-            warnings.warn("Observation contains NaNs")
-        if len(observation.shape) > 3:
-            warnings.warn("Observation has more than 3 dimensions")
-        if observation.shape == (0,):
-            assert False, "Observation can not be an empty array"
-        if observation.shape == (1,):
-            warnings.warn("Observation is a single number")
-        if not isinstance(observation, observation_0.__class__):
-            warnings.warn("Observations between agents are different classes")
-        if (observation.shape != observation_0.shape) and (
-            len(observation.shape) == len(observation_0.shape)
-        ):
-            if env_name not in env_diff_obs_shapes:
-                warnings.warn("Observations are different shapes")
-        if len(observation.shape) != len(observation_0.shape):
-            warnings.warn("Observations have different number of dimensions")
-        if not np.can_cast(observation.dtype, np.dtype("float64")):
-            warnings.warn("Observation numpy array is not a numeric dtype")
-        if np.array_equal(observation, np.zeros(observation.shape)):
-            if env_name not in env_all_zeros_obs:
-                warnings.warn("Observation numpy array is all zeros.")
-        if not np.all(observation >= 0) and (
+
+    if not isinstance(observation, np.ndarray) or (
+        env_name is not None and env_name not in env_obs_dicts
+    ):
+        warnings.warn("Observation is not NumPy array")
+        return
+    if np.isinf(observation).any():
+        warnings.warn(
+            "Observation contains infinity (np.inf) or negative infinity (-np.inf)"
+        )
+    if np.isnan(observation).any():
+        warnings.warn("Observation contains NaNs")
+    if len(observation.shape) > 3:
+        warnings.warn("Observation has more than 3 dimensions")
+    if observation.shape == (0,):
+        assert False, "Observation can not be an empty array"
+    if observation.shape == (1,):
+        warnings.warn("Observation is a single number")
+    if not isinstance(observation, observation_0.__class__):
+        warnings.warn("Observations between agents are different classes")
+    if (
+        (observation.shape != observation_0.shape)
+        and (len(observation.shape) == len(observation_0.shape))
+        and env_name not in env_diff_obs_shapes
+    ):
+        warnings.warn("Observations are different shapes")
+    if len(observation.shape) != len(observation_0.shape):
+        warnings.warn("Observations have different number of dimensions")
+    if not np.can_cast(observation.dtype, np.dtype("float64")):
+        warnings.warn("Observation numpy array is not a numeric dtype")
+    if (
+        np.array_equal(observation, np.zeros(observation.shape))
+        and env_name not in env_all_zeros_obs
+    ):
+        warnings.warn("Observation numpy array is all zeros.")
+    if (
+        not np.all(observation >= 0)
+        and (
             (len(observation.shape) == 2)
             or (len(observation.shape) == 3 and observation.shape[2] == 1)
             or (len(observation.shape) == 3 and observation.shape[2] == 3)
-        ):
-            if env_name not in env_graphical_obs:
-                warnings.warn(
-                    "The observation contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
-                )
-    else:
-        if env_name is not None and env_name not in env_dicts:
-            warnings.warn("Observation is not NumPy array")
+        )
+        and env_name not in env_graphical_obs
+    ):
+        warnings.warn(
+            "The observation contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
+        )
 
 
 def test_observation_action_spaces(env, agent_0):
-    env_obs_space = [
-        "leduc_holdem_v4",
-        "texas_holdem_no_limit_v6",
-        "texas_holdem_v4",
-        "go_v5",
-        "hanabi_v4",
-        "knights_archers_zombies_v10",
-        "chess_v5",
-        "connect_four_v3",
-        "tictactoe_v3",
-        "gin_rummy_v4",
-    ]
-    env_diff_agent_obs_size = [
-        "simple_adversary_v2",
-        "simple_world_comm_v2",
-        "simple_tag_v2",
-        "simple_crypto_v2",
-        "simple_push_v2",
-        "simple_speaker_listener_v3",
-    ]
-    env_pos_inf_obs = [
-        "simple_adversary_v2",
-        "simple_reference_v2",
-        "simple_spread_v2",
-        "simple_tag_v2",
-        "simple_world_comm_v2",
-        "multiwalker_v9",
-        "simple_crypto_v2",
-        "simple_push_v2",
-        "simple_speaker_listener_v3",
-        "simple_v2",
-    ]
-    env_neg_inf_obs = [
-        "simple_adversary_v2",
-        "simple_reference_v2",
-        "simple_spread_v2",
-        "simple_tag_v2",
-        "simple_world_comm_v2",
-        "multiwalker_v9",
-        "simple_crypto_v2",
-        "simple_push_v2",
-        "simple_speaker_listener_v3",
-        "simple_v2",
-    ]
     for agent in env.agents:
         assert isinstance(
             env.observation_space(agent), gymnasium.spaces.Space
@@ -144,14 +152,16 @@ def test_observation_action_spaces(env, agent_0):
         assert env.action_space(agent) is env.action_space(
             agent
         ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
-        if not (
-            isinstance(env.observation_space(agent), gymnasium.spaces.Box)
-            or isinstance(env.observation_space(agent), gymnasium.spaces.Discrete)
+        if (
+            not (
+                isinstance(env.observation_space(agent), gymnasium.spaces.Box)
+                or isinstance(env.observation_space(agent), gymnasium.spaces.Discrete)
+            )
+            and str(env.unwrapped) not in env_obs_space
         ):
-            if str(env.unwrapped) not in env_obs_space:
-                warnings.warn(
-                    "Observation space for each agent probably should be gymnasium.spaces.box or gymnasium.spaces.discrete"
-                )
+            warnings.warn(
+                "Observation space for each agent probably should be gymnasium.spaces.box or gymnasium.spaces.discrete"
+            )
         if not (
             isinstance(env.action_space(agent), gymnasium.spaces.Box)
             or isinstance(env.action_space(agent), gymnasium.spaces.Discrete)
@@ -177,9 +187,11 @@ def test_observation_action_spaces(env, agent_0):
             )
         if not isinstance(env.action_space(agent), env.action_space(agent).__class__):
             warnings.warn("The class of action spaces is different between two agents")
-        if env.observation_space(agent) != env.observation_space(agent_0):
-            if str(env.unwrapped) not in env_diff_agent_obs_size:
-                warnings.warn("Agents have different observation space sizes")
+        if (
+            env.observation_space(agent) != env.observation_space(agent_0)
+            and str(env.unwrapped) not in env_diff_agent_obs_size
+        ):
+            warnings.warn("Agents have different observation space sizes")
         if env.action_space(agent) != env.action_space(agent):
             warnings.warn("Agents have different action space sizes")
 
@@ -214,16 +226,20 @@ def test_observation_action_spaces(env, agent_0):
                 ), "Agent's action_space.high and action_space have different shapes"
 
         if isinstance(env.observation_space(agent), gymnasium.spaces.Box):
-            if np.any(np.equal(env.observation_space(agent).low, -np.inf)):
-                if str(env.unwrapped) not in env_neg_inf_obs:
-                    warnings.warn(
-                        "Agent's minimum observation space value is -infinity. This is probably too low."
-                    )
-            if np.any(np.equal(env.observation_space(agent).high, np.inf)):
-                if str(env.unwrapped) not in env_pos_inf_obs:
-                    warnings.warn(
-                        "Agent's maximum observation space value is infinity. This is probably too high"
-                    )
+            if (
+                np.any(np.equal(env.observation_space(agent).low, -np.inf))
+                and str(env.unwrapped) not in env_neg_inf_obs
+            ):
+                warnings.warn(
+                    "Agent's minimum observation space value is -infinity. This is probably too low."
+                )
+            if (
+                np.any(np.equal(env.observation_space(agent).high, np.inf))
+                and str(env.unwrapped) not in env_pos_inf_obs
+            ):
+                warnings.warn(
+                    "Agent's maximum observation space value is infinity. This is probably too high"
+                )
             if np.any(
                 np.equal(
                     env.observation_space(agent).low, env.observation_space(agent).high

--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -22,7 +22,29 @@ have {name} it should also not be possible for you to expose the possible_agents
 list and observation_spaces, action_spaces dictionaries."""
 
 
-def test_observation(observation, observation_0):
+def test_observation(observation, observation_0, env_name=None):
+    env_dicts = [
+        "leduc_holdem_v4",
+        "texas_holdem_no_limit_v6",
+        "texas_holdem_v4",
+        "go_v5",
+        "hanabi_v4",
+        "chess_v5",
+        "connect_four_v3",
+        "tictactoe_v3",
+        "gin_rummy_v4",
+    ]
+    env_graphical_obs = ["knights_archers_zombies_v10"]
+    env_diff_obs_shapes = [
+        "simple_adversary_v2",
+        "simple_world_comm_v2",
+        "simple_tag_v2",
+        "knights_archers_zombies_v10",
+        "simple_push_v2",
+        "simple_speaker_listener_v3",
+        "simple_crypto_v2",
+    ]
+    env_all_zeros_obs = ["knights_archers_zombies_v10"]
     if isinstance(observation, np.ndarray):
         if np.isinf(observation).any():
             warnings.warn(
@@ -41,26 +63,74 @@ def test_observation(observation, observation_0):
         if (observation.shape != observation_0.shape) and (
             len(observation.shape) == len(observation_0.shape)
         ):
-            warnings.warn("Observations are different shapes")
+            if env_name not in env_diff_obs_shapes:
+                warnings.warn("Observations are different shapes")
         if len(observation.shape) != len(observation_0.shape):
             warnings.warn("Observations have different number of dimensions")
         if not np.can_cast(observation.dtype, np.dtype("float64")):
             warnings.warn("Observation numpy array is not a numeric dtype")
         if np.array_equal(observation, np.zeros(observation.shape)):
-            warnings.warn("Observation numpy array is all zeros.")
+            if env_name not in env_all_zeros_obs:
+                warnings.warn("Observation numpy array is all zeros.")
         if not np.all(observation >= 0) and (
             (len(observation.shape) == 2)
             or (len(observation.shape) == 3 and observation.shape[2] == 1)
             or (len(observation.shape) == 3 and observation.shape[2] == 3)
         ):
-            warnings.warn(
-                "The observation contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
-            )
+            if env_name not in env_graphical_obs:
+                warnings.warn(
+                    "The observation contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
+                )
     else:
-        warnings.warn("Observation is not NumPy array")
+        if env_name is not None and env_name not in env_dicts:
+            warnings.warn("Observation is not NumPy array")
 
 
 def test_observation_action_spaces(env, agent_0):
+    env_obs_space = [
+        "leduc_holdem_v4",
+        "texas_holdem_no_limit_v6",
+        "texas_holdem_v4",
+        "go_v5",
+        "hanabi_v4",
+        "knights_archers_zombies_v10",
+        "chess_v5",
+        "connect_four_v3",
+        "tictactoe_v3",
+        "gin_rummy_v4",
+    ]
+    env_diff_agent_obs_size = [
+        "simple_adversary_v2",
+        "simple_world_comm_v2",
+        "simple_tag_v2",
+        "simple_crypto_v2",
+        "simple_push_v2",
+        "simple_speaker_listener_v3",
+    ]
+    env_pos_inf_obs = [
+        "simple_adversary_v2",
+        "simple_reference_v2",
+        "simple_spread_v2",
+        "simple_tag_v2",
+        "simple_world_comm_v2",
+        "multiwalker_v9",
+        "simple_crypto_v2",
+        "simple_push_v2",
+        "simple_speaker_listener_v3",
+        "simple_v2",
+    ]
+    env_neg_inf_obs = [
+        "simple_adversary_v2",
+        "simple_reference_v2",
+        "simple_spread_v2",
+        "simple_tag_v2",
+        "simple_world_comm_v2",
+        "multiwalker_v9",
+        "simple_crypto_v2",
+        "simple_push_v2",
+        "simple_speaker_listener_v3",
+        "simple_v2",
+    ]
     for agent in env.agents:
         assert isinstance(
             env.observation_space(agent), gymnasium.spaces.Space
@@ -78,9 +148,10 @@ def test_observation_action_spaces(env, agent_0):
             isinstance(env.observation_space(agent), gymnasium.spaces.Box)
             or isinstance(env.observation_space(agent), gymnasium.spaces.Discrete)
         ):
-            warnings.warn(
-                "Observation space for each agent probably should be gymnasium.spaces.box or gymnasium.spaces.discrete"
-            )
+            if str(env.unwrapped) not in env_obs_space:
+                warnings.warn(
+                    "Observation space for each agent probably should be gymnasium.spaces.box or gymnasium.spaces.discrete"
+                )
         if not (
             isinstance(env.action_space(agent), gymnasium.spaces.Box)
             or isinstance(env.action_space(agent), gymnasium.spaces.Discrete)
@@ -107,7 +178,8 @@ def test_observation_action_spaces(env, agent_0):
         if not isinstance(env.action_space(agent), env.action_space(agent).__class__):
             warnings.warn("The class of action spaces is different between two agents")
         if env.observation_space(agent) != env.observation_space(agent_0):
-            warnings.warn("Agents have different observation space sizes")
+            if str(env.unwrapped) not in env_diff_agent_obs_size:
+                warnings.warn("Agents have different observation space sizes")
         if env.action_space(agent) != env.action_space(agent):
             warnings.warn("Agents have different action space sizes")
 
@@ -143,13 +215,15 @@ def test_observation_action_spaces(env, agent_0):
 
         if isinstance(env.observation_space(agent), gymnasium.spaces.Box):
             if np.any(np.equal(env.observation_space(agent).low, -np.inf)):
-                warnings.warn(
-                    "Agent's minimum observation space value is -infinity. This is probably too low."
-                )
+                if str(env.unwrapped) not in env_neg_inf_obs:
+                    warnings.warn(
+                        "Agent's minimum observation space value is -infinity. This is probably too low."
+                    )
             if np.any(np.equal(env.observation_space(agent).high, np.inf)):
-                warnings.warn(
-                    "Agent's maximum observation space value is infinity. This is probably too high"
-                )
+                if str(env.unwrapped) not in env_pos_inf_obs:
+                    warnings.warn(
+                        "Agent's maximum observation space value is infinity. This is probably too high"
+                    )
             if np.any(
                 np.equal(
                     env.observation_space(agent).low, env.observation_space(agent).high
@@ -302,7 +376,7 @@ def play_test(env, observation_0, num_cycles):
         assert env.observation_space(agent).contains(
             prev_observe
         ), "Agent's observation is outside of it's observation space"
-        test_observation(prev_observe, observation_0)
+        test_observation(prev_observe, observation_0, str(env.unwrapped))
         if not isinstance(env.infos[env.agent_selection], dict):
             warnings.warn(
                 "The info of each agent should be a dict, use {} if you aren't using info"
@@ -392,7 +466,7 @@ def api_test(env, num_cycles=1000, verbose_progress=False):
 
     env.reset()
     observation_0, *_ = env.last()
-    test_observation(observation_0, observation_0)
+    test_observation(observation_0, observation_0, str(env.unwrapped))
 
     non_observe, *_ = env.last(observe=False)
     assert non_observe is None, "last must return a None when observe=False"

--- a/pettingzoo/test/state_test.py
+++ b/pettingzoo/test/state_test.py
@@ -5,6 +5,28 @@ import numpy as np
 
 
 def test_state_space(env):
+    env_pos_inf_state = [
+        "simple_adversary_v2",
+        "simple_reference_v2",
+        "simple_spread_v2",
+        "simple_tag_v2",
+        "simple_world_comm_v2",
+        "simple_crypto_v2",
+        "simple_push_v2",
+        "simple_speaker_listener_v3",
+        "simple_v2",
+    ]
+    env_neg_inf_state = [
+        "simple_adversary_v2",
+        "simple_reference_v2",
+        "simple_spread_v2",
+        "simple_tag_v2",
+        "simple_world_comm_v2",
+        "simple_crypto_v2",
+        "simple_push_v2",
+        "simple_speaker_listener_v3",
+        "simple_v2",
+    ]
     assert isinstance(
         env.state_space, gymnasium.spaces.Space
     ), "State space for each environment must extend gymnasium.spaces.Space"
@@ -18,13 +40,15 @@ def test_state_space(env):
 
     if isinstance(env.state_space, gymnasium.spaces.Box):
         if np.any(np.equal(env.state_space.low, -np.inf)):
-            warnings.warn(
-                "Environment's minimum state space value is -infinity. This is probably too low."
-            )
+            if str(env.unwrapped) not in env_neg_inf_state:
+                warnings.warn(
+                    "Environment's minimum state space value is -infinity. This is probably too low."
+                )
         if np.any(np.equal(env.state_space.high, np.inf)):
-            warnings.warn(
-                "Environment's maximum state space value is infinity. This is probably too high"
-            )
+            if str(env.unwrapped) not in env_pos_inf_state:
+                warnings.warn(
+                    "Environment's maximum state space value is infinity. This is probably too high"
+                )
         if np.any(np.equal(env.state_space.low, env.state_space.high)):
             warnings.warn(
                 "Environment's maximum and minimum state space values are equal"
@@ -44,6 +68,7 @@ def test_state_space(env):
 
 
 def test_state(env, num_cycles):
+    graphical_envs = ["knights_archers_zombies_v10"]
     env.reset()
     state_0 = env.state()
     for agent in env.agent_iter(env.num_agents * num_cycles):
@@ -88,11 +113,13 @@ def test_state(env, num_cycles):
                 or (len(new_state.shape) == 3 and new_state.shape[2] == 1)
                 or (len(new_state.shape) == 3 and new_state.shape[2] == 3)
             ):
-                warnings.warn(
-                    "The state contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
-                )
+                if str(env.unwrapped) not in graphical_envs:
+                    warnings.warn(
+                        "The state contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
+                    )
         else:
-            warnings.warn("State is not NumPy array")
+            if str(env.unwrapped) not in graphical_envs:
+                warnings.warn("State is not NumPy array")
 
 
 def test_parallel_env(parallel_env):

--- a/pettingzoo/test/state_test.py
+++ b/pettingzoo/test/state_test.py
@@ -3,30 +3,32 @@ import warnings
 import gymnasium
 import numpy as np
 
+env_pos_inf_state = [
+    "simple_adversary_v2",
+    "simple_reference_v2",
+    "simple_spread_v2",
+    "simple_tag_v2",
+    "simple_world_comm_v2",
+    "simple_crypto_v2",
+    "simple_push_v2",
+    "simple_speaker_listener_v3",
+    "simple_v2",
+]
+env_neg_inf_state = [
+    "simple_adversary_v2",
+    "simple_reference_v2",
+    "simple_spread_v2",
+    "simple_tag_v2",
+    "simple_world_comm_v2",
+    "simple_crypto_v2",
+    "simple_push_v2",
+    "simple_speaker_listener_v3",
+    "simple_v2",
+]
+
 
 def test_state_space(env):
-    env_pos_inf_state = [
-        "simple_adversary_v2",
-        "simple_reference_v2",
-        "simple_spread_v2",
-        "simple_tag_v2",
-        "simple_world_comm_v2",
-        "simple_crypto_v2",
-        "simple_push_v2",
-        "simple_speaker_listener_v3",
-        "simple_v2",
-    ]
-    env_neg_inf_state = [
-        "simple_adversary_v2",
-        "simple_reference_v2",
-        "simple_spread_v2",
-        "simple_tag_v2",
-        "simple_world_comm_v2",
-        "simple_crypto_v2",
-        "simple_push_v2",
-        "simple_speaker_listener_v3",
-        "simple_v2",
-    ]
+
     assert isinstance(
         env.state_space, gymnasium.spaces.Space
     ), "State space for each environment must extend gymnasium.spaces.Space"
@@ -39,16 +41,20 @@ def test_state_space(env):
         )
 
     if isinstance(env.state_space, gymnasium.spaces.Box):
-        if np.any(np.equal(env.state_space.low, -np.inf)):
-            if str(env.unwrapped) not in env_neg_inf_state:
-                warnings.warn(
-                    "Environment's minimum state space value is -infinity. This is probably too low."
-                )
-        if np.any(np.equal(env.state_space.high, np.inf)):
-            if str(env.unwrapped) not in env_pos_inf_state:
-                warnings.warn(
-                    "Environment's maximum state space value is infinity. This is probably too high"
-                )
+        if (
+            np.any(np.equal(env.state_space.low, -np.inf))
+            and str(env.unwrapped) not in env_neg_inf_state
+        ):
+            warnings.warn(
+                "Environment's minimum state space value is -infinity. This is probably too low."
+            )
+        if (
+            np.any(np.equal(env.state_space.high, np.inf))
+            and str(env.unwrapped) not in env_pos_inf_state
+        ):
+            warnings.warn(
+                "Environment's maximum state space value is infinity. This is probably too high"
+            )
         if np.any(np.equal(env.state_space.low, env.state_space.high)):
             warnings.warn(
                 "Environment's maximum and minimum state space values are equal"
@@ -83,43 +89,48 @@ def test_state(env, num_cycles):
         assert env.state_space.contains(
             new_state
         ), "Environment's state is outside of it's state space"
-        if isinstance(new_state, np.ndarray):
-            if np.isinf(new_state).any():
-                warnings.warn(
-                    "State contains infinity (np.inf) or negative infinity (-np.inf)"
-                )
-            if np.isnan(new_state).any():
-                warnings.warn("State contains NaNs")
-            if len(new_state.shape) > 3:
-                warnings.warn("State has more than 3 dimensions")
-            if new_state.shape == (0,):
-                assert False, "State can not be an empty array"
-            if new_state.shape == (1,):
-                warnings.warn("State is a single number")
-            if not isinstance(new_state, state_0.__class__):
-                warnings.warn("State between Observations are different classes")
-            if (new_state.shape != state_0.shape) and (
-                len(new_state.shape) == len(state_0.shape)
-            ):
-                warnings.warn("States are different shapes")
-            if len(new_state.shape) != len(state_0.shape):
-                warnings.warn("States have different number of dimensions")
-            if not np.can_cast(new_state.dtype, np.dtype("float64")):
-                warnings.warn("State numpy array is not a numeric dtype")
-            if np.array_equal(new_state, np.zeros(new_state.shape)):
-                warnings.warn("State numpy array is all zeros.")
-            if not np.all(new_state >= 0) and (
+        if (
+            not isinstance(new_state, np.ndarray)
+            and str(env.unwrapped) not in graphical_envs
+        ):
+            warnings.warn("State is not NumPy array")
+            return
+        if np.isinf(new_state).any():
+            warnings.warn(
+                "State contains infinity (np.inf) or negative infinity (-np.inf)"
+            )
+        if np.isnan(new_state).any():
+            warnings.warn("State contains NaNs")
+        if len(new_state.shape) > 3:
+            warnings.warn("State has more than 3 dimensions")
+        if new_state.shape == (0,):
+            assert False, "State can not be an empty array"
+        if new_state.shape == (1,):
+            warnings.warn("State is a single number")
+        if not isinstance(new_state, state_0.__class__):
+            warnings.warn("State between Observations are different classes")
+        if (new_state.shape != state_0.shape) and (
+            len(new_state.shape) == len(state_0.shape)
+        ):
+            warnings.warn("States are different shapes")
+        if len(new_state.shape) != len(state_0.shape):
+            warnings.warn("States have different number of dimensions")
+        if not np.can_cast(new_state.dtype, np.dtype("float64")):
+            warnings.warn("State numpy array is not a numeric dtype")
+        if np.array_equal(new_state, np.zeros(new_state.shape)):
+            warnings.warn("State numpy array is all zeros.")
+        if (
+            not np.all(new_state >= 0)
+            and (
                 (len(new_state.shape) == 2)
                 or (len(new_state.shape) == 3 and new_state.shape[2] == 1)
                 or (len(new_state.shape) == 3 and new_state.shape[2] == 3)
-            ):
-                if str(env.unwrapped) not in graphical_envs:
-                    warnings.warn(
-                        "The state contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
-                    )
-        else:
-            if str(env.unwrapped) not in graphical_envs:
-                warnings.warn("State is not NumPy array")
+            )
+            and str(env.unwrapped) not in graphical_envs
+        ):
+            warnings.warn(
+                "The state contains negative numbers and is in the shape of a graphical observation. This might be a bad thing."
+            )
 
 
 def test_parallel_env(parallel_env):


### PR DESCRIPTION
# Description

Fixing a large number of test warnings. These warnings were being caused by mismatches between an environment's specifications and the tests. For example a warning was being thrown for "simple_adversary_v2" because the state space had a maximum possible value of np.inf, but that is valid according to the env's specs. 

The method that I took to do these changes is to create lists of envs that have these violation specifications. Then if a warning should be thrown, there is an if statement that first checks if that environments name is in the associated list. For example there is a list looking for maximum state space of positive infinity. Only if an environment's name is not in the list will the warning be thrown. 

One of the files just this if statement functionality was added, the state_test file needed the env name passed to the function as the env itself was not passed. 


